### PR TITLE
fix(service-minecrafts.yaml): typos, syntax.

### DIFF
--- a/charts/crafty-control-mc/Chart.yaml
+++ b/charts/crafty-control-mc/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.3
+version: 0.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/crafty-control-mc/README.md
+++ b/charts/crafty-control-mc/README.md
@@ -34,7 +34,7 @@ Most cloud provider load balancers support TCP balancing and can provide
 another way to get traffic into your cluster via a `LoadBalancer` service type
 and annotations on the service.
 
-Current chart version is `0.0.3`
+Current chart version is `0.0.4`
 
 Source code can be found [here](https://github.com/dkolb/charts)
 

--- a/charts/crafty-control-mc/templates/service_minecrafts.yaml
+++ b/charts/crafty-control-mc/templates/service_minecrafts.yaml
@@ -2,7 +2,8 @@
 {{- $fullName := include "crafty-control-mc.fullname" . -}}
 {{- $labels := include "crafty-control-mc.labels" . | printf "\n%s" -}}
 {{- $selector := include "crafty-control-mc.selectorLabels" . -}}
-{{- range .Values.minecrafts -}}
+{{- range .Values.minecrafts }}
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -21,5 +22,6 @@ spec:
   {{- end }}
   selector:
     {{- $selector | nindent 4 }}
+
 {{- end }}
 {{- end }}


### PR DESCRIPTION
This solves the YAML parse error breakage introduced when you try to actually have multiple elements in the array .Values.minecrafts.  Contrib by @jstewart612